### PR TITLE
Fixed order table action icons for WC 3.3.1

### DIFF
--- a/woocommerce-delivery-notes/css/admin.css
+++ b/woocommerce-delivery-notes/css/admin.css
@@ -46,7 +46,8 @@
 
 /* All orders */
 
-.type-shop_order .column-order_actions .print-preview-button {
+.type-shop_order .column-order_actions .print-preview-button,
+.type-shop_order .column-wc_actions .print-preview-button {
 	display: block;
 	text-indent: -9999px;
 	position: relative;
@@ -57,7 +58,8 @@
 	width: 2em;
 }
 
-.type-shop_order .column-order_actions .print-preview-button:before {
+.type-shop_order .column-order_actions .print-preview-button:before,
+.type-shop_order .column-wc_actions .print-preview-button:before {
 	font-family: "icons";
 	speak: none;
 	font-weight: normal;
@@ -78,28 +80,34 @@
 	content: "\e603";
 } 
 
-.type-shop_order .column-order_actions .print-preview-button.invoice:before {
+.type-shop_order .column-order_actions .print-preview-button.invoice:before,
+.type-shop_order .column-wc_actions .print-preview-button.invoice:before {
 	content: "\e602";
 }
 
-.type-shop_order .column-order_actions .print-preview-button.delivery-note:before {
+.type-shop_order .column-order_actions .print-preview-button.delivery-note:before,
+.type-shop_order .column-wc_actions .print-preview-button.delivery-note:before {
 	content: "\e601";
 }
 
-.type-shop_order .column-order_actions .print-preview-button.receipt:before {
+.type-shop_order .column-order_actions .print-preview-button.receipt:before,
+.type-shop_order .column-wc_actions .print-preview-button.receipt:before {
 	content: "\e604";
 }
 
-.type-shop_order .column-order_actions .print-preview-button.credit-note:before {
+.type-shop_order .column-order_actions .print-preview-button.credit-note:before,
+.type-shop_order .column-wc_actions .print-preview-button.credit-note:before {
 	content: "\e600";
 }
 
-.type-shop_order .column-order_actions span.print-preview-loading {
+.type-shop_order .column-order_actions span.print-preview-loading,
+.type-shop_order .column-wc_actions span.print-preview-loading {
 	float: left;
 	margin-top: 3px;
 }
 
-.type-shop_order .column-order_actions .print-preview-button span {
+.type-shop_order .column-order_actions .print-preview-button span,
+.type-shop_order .column-wc_actions .print-preview-button span {
 	display:  none;
 }
 


### PR DESCRIPTION
As #37 was indicating, there is a bug where the order table listing icons are not being displayed in WC 3.3.1. This was a result of a CSS class name change. This PR is a fix for this. I have fixed it for WC 3.3.1+ while keeping it backwards compatible to older versions of WC. I hope this helps.