### PR TITLE
Add buttom name filters

### DIFF
--- a/woocommerce-delivery-notes/includes/class-wcdn-theme.php
+++ b/woocommerce-delivery-notes/includes/class-wcdn-theme.php
@@ -54,7 +54,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 				$wdn_order_id =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_id() : $order->id;
 				$actions['print'] = array(
 					'url'  => wcdn_get_print_link( $wdn_order_id, $this->get_template_type( $order ) ),
-					'name' => __( 'Print', 'woocommerce-delivery-notes' )
+					'name' => apply_filters( 'wcdn_print_button_name_on_my_account_page', __( 'Print', 'woocommerce-delivery-notes' ), $order )
 				);
 			}
 			return $actions;
@@ -91,7 +91,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 
 				?>
 				<p class="order-print">
-					<a href="<?php echo $print_url; ?>" class="button print"><?php _e( 'Print', 'woocommerce-delivery-notes' ); ?></a>
+					<a href="<?php echo $print_url; ?>" class="button print"><?php echo apply_filters( 'wcdn_print_button_name_order_page', __( 'Print', 'woocommerce-delivery-notes' ), $order ); ?></a>
 				</p>
 				<?php
 			}


### PR DESCRIPTION
I wanted to change the name of the print button.
So I added the following filter hooks.

- `wcdn_print_button_name_on_my_account_page`
- `wcdn_print_button_name_order_page`

For example, use as follows.

```
add_filter( 'wcdn_print_button_name_on_my_account_page', function( $name, $order ) {
    if ( 'completed' === $order->get_status() ) {
        $name = 'Print Invoice';
    } else {
        $name = 'Print Order';
    }

    return $name;
}, 10, 2);
```
