### PR TITLE
Add filter to change template type arbitrarily

### DIFF
--- a/woocommerce-delivery-notes/includes/class-wcdn-theme.php
+++ b/woocommerce-delivery-notes/includes/class-wcdn-theme.php
@@ -134,6 +134,9 @@ echo "\n****************************************************\n\n";
 			} else {
 				$type = apply_filters( 'wcdn_theme_print_button_template_type', 'order' );
 			}
+
+			$type = apply_filters( 'wcdn_theme_print_button_template_type_arbitrary', $type, $order );
+
 			return $type;
 		}
 


### PR DESCRIPTION
I wanted to change the template type according to any order status.
So I added the following filter hook.

- `wcdn_theme_print_button_template_type_arbitrary`

For example, use as follows.

```
add_filter( 'wcdn_theme_print_button_template_type_arbitrary', function( $type, $order ) {
    if ( 'completed' === $order->get_status() ) {
        $type = 'receipt';
    } else if ( 'on-hold' === $order->get_status() ) {
        $type = 'invoice';
    } else {
        $type = 'order';
    }

    return $type;
}, 10, 2 );
```
