### PR TITLE
Removed esc_html_e & replaced with esc_html

### DIFF
--- a/woocommerce-delivery-notes/includes/wcdn-template-functions.php
+++ b/woocommerce-delivery-notes/includes/wcdn-template-functions.php
@@ -153,7 +153,7 @@ function wcdn_template_stylesheet() {
 	$name = apply_filters( 'wcdn_template_stylesheet_name', 'style.css' );
 	// phpcs:disable
 	?>
-	<link rel="stylesheet" href="<?php echo esc_url( $wcdn->print->get_template_file_location( $name, true ) ) . esc_html_e( $name, 'woocommerce-delivery-notes' ); ?>" type="text/css" media="screen,print" />
+	<link rel="stylesheet" href="<?php echo esc_url( $wcdn->print->get_template_file_location( $name, true ) ) . esc_html( $name ); ?>" type="text/css" media="screen,print" />
 	<?php
 	// phpcs:enable
 }


### PR DESCRIPTION
Removed esc_html_e & replaced with esc_html(). It was wrongly used on a variable that's only a file name. Due to this, the CSS file style.css was not loading, hence the template format was not coming proper.
Fix #93