### PR TITLE
Version 4.4.9

### DIFF
--- a/woocommerce-delivery-notes/includes/class-woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes/includes/class-woocommerce-delivery-notes.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 		 *
 		 * @var string $plugin_version Current plugin version number
 		 */
-		public static $plugin_version = '4.4.8';
+		public static $plugin_version = '4.4.9';
 
 		/**
 		 * Plugin URL on current installation

--- a/woocommerce-delivery-notes/readme.txt
+++ b/woocommerce-delivery-notes/readme.txt
@@ -1,12 +1,12 @@
 	=== WooCommerce Print Invoice & Delivery Note ===
 
-Contributors: ashokrane, bhavik.kiri, tychesoftwares, rashmim
+Contributors: ashokrane, tychesoftwares, rashmim
 Donate link: https://www.paypal.me/TycheSoftwares
 Tags: delivery note, packing slip, pdf invoice, delivery, shipping, print order, woocommerce, woothemes, shop
 Requires at least: 4.0
-Tested up to: 5.1
+Tested up to: 5.2
 Author URI: https://www.tychesoftwares.com/
-Stable tag: 4.4.8
+Stable tag: trunk
 License: GPLv3 or later
 License URI: http://www.opensource.org/licenses/gpl-license.php
 
@@ -328,9 +328,16 @@ Please [contribute your translation](https://github.com/TycheSoftwares/woocommer
 
 == Changelog ==
 
-= Minimum Requirements: WooCommerce 2.2 =
+= Minimum Requirements: WooCommerce 3.0 =
 
-= 4.4.7 (02.04.2019) =
+= 4.4.9 (21.08.2019) =
+
+* Made the plugin code compliant with WPCS coding standards
+* Added filter wcdn_theme_print_button_template_type_arbitrary - this filter hook allows to change template type based on order status
+* Added filters wcdn_print_button_name_on_my_account_page, wcdn_print_button_name_order_page - these filter hooks allows to change the label of the Print button
+* When plugin is uninstalled, data cleanup wasn't happening. This has been fixed.
+
+= 4.4.8 (02.04.2019) =
 
 * Fix - When a noticed was dismissed from the plugin, then it will dismiss all other notices from other plugins also. This is fixed now. 
 * Fix - Some errors in debug.log file are fixed. 

--- a/woocommerce-delivery-notes/woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes/woocommerce-delivery-notes.php
@@ -5,7 +5,7 @@
  * Plugin Name: WooCommerce Print Invoice & Delivery Note
  * Plugin URI: https://www.tychesoftwares.com/
  * Description: Print Invoices & Delivery Notes for WooCommerce Orders.
- * Version: 4.4.8
+ * Version: 4.4.9
  * Author: Tyche Softwares
  * Author URI: https://www.tychesoftwares.com/
  * License: GPLv3 or later
@@ -14,9 +14,10 @@
  * Domain Path: /languages
  * Requires PHP: 5.6
  * WC requires at least: 3.0.0
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.7
+ * Tested up to: 5.2
  *
- * Copyright 2015 Tyche Softwares
+ * Copyright 2019 Tyche Softwares
  *
  *     This file is part of WooCommerce Print Invoices & Delivery Notes,
  *     a plugin for WordPress.


### PR DESCRIPTION
Changelog for v4.4.9

1. Made the plugin code compliant with WPCS coding standards

2. Added 3 new filters:
 - wcdn_theme_print_button_template_type_arbitrary - this filter hook allows to change template type based on order status
 - wcdn_print_button_name_on_my_account_page, wcdn_print_button_name_order_page - this filter hook allows to change the label of the Print button

3. When plugin is uninstalled, data cleanup wasn't happening. This has been fixed.