### PR TITLE
Fix for print not working for PHP below 7.0

### DIFF
--- a/woocommerce-delivery-notes/includes/class-woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes/includes/class-woocommerce-delivery-notes.php
@@ -149,7 +149,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 		 * Define WC Constants.
 		 */
 		private function define_constants() {
-			self::$plugin_basefile_path = dirname( __FILE__, 2 ) . '/woocommerce-delivery-notes.php';
+			self::$plugin_basefile_path = dirname( dirname( __FILE__ ) ) . '/woocommerce-delivery-notes.php';
 			self::$plugin_basefile      = plugin_basename( self::$plugin_basefile_path );
 			self::$plugin_url           = plugin_dir_url( self::$plugin_basefile );
 			self::$plugin_path          = trailingslashit( dirname( self::$plugin_basefile_path ) );


### PR DESCRIPTION
The dirname() was causing the issue with PHP versions lower then 7.0 due to it's optional 2nd parameter. Fix #105