### PR TITLE
Function using was deprecated from WC4.4.0 hence changed the function which will not return errors in debug log

### DIFF
--- a/woocommerce-delivery-notes/templates/print-order/print-content.php
+++ b/woocommerce-delivery-notes/templates/print-order/print-content.php
@@ -107,7 +107,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php foreach ( $order->get_items() as $item ) : ?>
 
 						<?php
-							$product = apply_filters( 'wcdn_order_item_product', $order->get_product_from_item( $item ), $item );
+							$product = apply_filters( 'wcdn_order_item_product', $item->get_product(), $item );
 
 						if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 							$item_meta = new WC_Order_Item_Product( $item['item_meta'], $product );


### PR DESCRIPTION
Function using was deprecated from WC4.4.0 hence changed the function which will not return errors in debug log.