### PR TITLE
remove logo size for default template

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -493,3 +493,8 @@ span.remove-image {
 .wcdn-footer .ft-text p { line-height: 25px; margin-bottom: 22px; }
 .wcdn-footer .ft-text p:last-child { margin-bottom: 0; }
 .wcdn-footer .ft-text .rating { font-size: 17px; color: #FFBA00; }
+.custom-label {
+	font-size: 14px;
+    font-weight: 600;
+	max-width: 12% !important;
+}

--- a/includes/admin/views/Preview_template/deliverynote-preview-template.php
+++ b/includes/admin/views/Preview_template/deliverynote-preview-template.php
@@ -139,6 +139,9 @@ if ( is_null( $parent_order ) ) {
 			$order_number   = $order->get_order_number();
 			$order_date     = $order->get_date_created()->format( 'F j, Y' );
 			$payment_method = $order->get_payment_method();
+			if ( empty( $invoice_number ) ) {
+				$invoice_number = get_option( 'wcdn_invoice_number_count' );
+			}
 			?>
 			<div class="invoice-number" v-show="deliverynote.invoice_number" :style="{ text: deliverynote.invoice_number_text, fontWeight: deliverynote.invoice_number_style, color: deliverynote.invoice_number_text_colour, fontSize: deliverynote.invoice_number_font_size + 'px' }">
 				<li>

--- a/includes/admin/views/Preview_template/invoice-preview-template.php
+++ b/includes/admin/views/Preview_template/invoice-preview-template.php
@@ -136,6 +136,9 @@ if ( is_null( $parent_order ) ) {
 					$order_number   = $order->get_order_number();
 					$order_date     = $order->get_date_created()->format( 'F j, Y' );
 					$payment_method = $order->get_payment_method();
+					if ( empty( $invoice_number ) ) {
+						$invoice_number = get_option( 'wcdn_invoice_number_count' );
+					}
 					?>
 					<div class="invoice-number" v-show="invoice.invoice_number" :style="{ text: invoice.invoice_number_text, fontWeight: invoice.invoice_number_style, color: invoice.invoice_number_text_colour, fontSize: invoice.invoice_number_font_size + 'px' }">
 						<li>

--- a/includes/admin/views/Preview_template/receipt-preview-template.php
+++ b/includes/admin/views/Preview_template/receipt-preview-template.php
@@ -141,7 +141,12 @@ if ( is_null( $parent_order ) ) {
 			$payment_method         = $order->get_payment_method();
 			$date_formate           = get_option( 'date_format' );
 			$wdn_order_payment_date = $order->get_date_paid();
-			$payment_date           = __( date( $date_formate, strtotime( $wdn_order_payment_date ) ), 'woocommerce' ); // phpcs:ignore
+			if ( $wdn_order_payment_date ) {
+				$payment_date_formatted = $wdn_order_payment_date->date( $date_formate );
+				$payment_date           = __( $payment_date_formatted, 'woocommerce' ); // phpcs:ignore
+			} else {
+				$payment_date = $order->get_date_created()->format( 'F j, Y' );
+			}
 			?>
 			<div class="invoice-number" v-show="receipt.invoice_number" :style="{ text: receipt.invoice_number_text, fontWeight: receipt.invoice_number_style, color: receipt.invoice_number_text_colour, fontSize: receipt.invoice_number_font_size + 'px' }">
 				<li>

--- a/includes/admin/views/Preview_template/receipt-preview-template.php
+++ b/includes/admin/views/Preview_template/receipt-preview-template.php
@@ -135,7 +135,10 @@ if ( is_null( $parent_order ) ) {
 	<div class="order-info">
 		<ul class="info-list">
 			<?php
-			$invoice_number         = $order->get_meta( '_wcdn_invoice_number' );
+			$invoice_number = $order->get_meta( '_wcdn_invoice_number' );
+			if ( empty( $invoice_number ) ) {
+				$invoice_number = get_option( 'wcdn_invoice_number_count' );
+			}
 			$order_number           = $order->get_order_number();
 			$order_date             = $order->get_date_created()->format( 'F j, Y' );
 			$payment_method         = $order->get_payment_method();

--- a/includes/admin/views/wcdn-document.php
+++ b/includes/admin/views/wcdn-document.php
@@ -15,7 +15,7 @@ if ( isset( $_GET['wdcn_setting'] ) ) {
 	</select>
 	<div style="margin-top:35px">
 		<div class="form-group row">
-			<label for="enable_invoice" class="col-sm-2 col-form-label"><?php esc_html_e( 'Enable Invoice', 'woocommerce-delivery-notes' ); ?></label>
+			<label for="enable_invoice" class="custom-label"><?php esc_html_e( 'Enable Invoice', 'woocommerce-delivery-notes' ); ?></label>
 				<div class="col-sm-6 icon-flex">
 					<i class="dashicons dashicons-info" data-toggle="tooltip" data-placement="bottom" title="<?php esc_html_e( 'Enable button that will display on admin side order page.', 'woocommerce-delivery-notes' ); ?>"></i>
 					<label class="switch">
@@ -25,7 +25,7 @@ if ( isset( $_GET['wdcn_setting'] ) ) {
 				</div>
 			</div>
 			<div class="form-group row">
-				<label for="enable_receipt" class="col-sm-2 col-form-label"><?php esc_html_e( 'Enable Receipt', 'woocommerce-delivery-notes' ); ?></label>
+				<label for="enable_receipt" class="custom-label"><?php esc_html_e( 'Enable Receipt', 'woocommerce-delivery-notes' ); ?></label>
 				<div class="col-sm-6 icon-flex">
 					<i class="dashicons dashicons-info" data-toggle="tooltip" data-placement="bottom" title="<?php esc_html_e( 'Enable button that will display on admin side order page.', 'woocommerce-delivery-notes' ); ?>"></i>
 					<label class="switch">

--- a/includes/admin/views/wcdn-general.php
+++ b/includes/admin/views/wcdn-general.php
@@ -174,7 +174,7 @@ $shop_logotitle = get_the_title( $shop_logoid );
 <div class="form-group row">
 	<label for="store_pdf" class="col-sm-2 col-form-label">Store PDF files for X days </label>
 	<div class="col-sm-6 icon-flex">
-		<i class="dashicons dashicons-info" data-toggle="tooltip" data-placement="bottom" title="<?php esc_html_e( 'To store PDF files for a specific duration, such as X days. Default value is 7 days.', 'woocommerce-delivery-notes' ); ?>"></i>
+		<i class="dashicons dashicons-info" data-toggle="tooltip" data-placement="bottom" title="<?php esc_html_e( 'To Store PDF files in the \wp-content\uploads\wcdn\ folder for a specific duration, like X days, with a default value of 7 days', 'woocommerce-delivery-notes' ); ?>"></i>
 		<?php
 		if ( isset( $data['store_pdf'] ) ) {
 			$store_pdf = $data['store_pdf'];

--- a/includes/wcdn-template-functions.php
+++ b/includes/wcdn-template-functions.php
@@ -231,15 +231,13 @@ function wcdn_company_logo() {
 	global $wcdn;
 	$attachment_id = wcdn_get_company_logo_id();
 	$company       = get_option( 'wcdn_custom_company_name' );
-	$sizeh         = get_option( 'wcdn_general_settings' )['logo_size']['sizeh'];
-	$sizew         = get_option( 'wcdn_general_settings' )['logo_size']['sizew'];
 	if ( $attachment_id ) {
 		$attachment_src = wp_get_attachment_image_src( $attachment_id, 'full', false );
 		// resize the image to a 1/4 of the original size to have a printing point density of about 288ppi.
 		?>
 		<div class="logo">
-			<img src="<?php echo esc_url( $attachment_src[0] ); ?>" class="desktop" width="<?php echo esc_attr( $sizew ); ?>" height="<?php echo esc_attr( $sizeh ); ?>" alt="<?php echo esc_attr( $company ); ?>" />
-			<img src="<?php echo esc_url( $attachment_src[0] ); ?>" class="mobile" width="<?php echo esc_attr( $sizew ); ?>" height="<?php echo esc_attr( $sizeh ); ?>" alt="<?php echo esc_attr( $company ); ?>" />
+			<img src="<?php echo esc_url( $attachment_src[0] ); ?>"  class="desktop"  width="<?php echo esc_attr( round( $attachment_src[1] / 4 ) ); ?>" height="<?php echo esc_attr( round( $attachment_src[2] / 4 ) ); ?>" alt="<?php echo esc_attr( $company ); ?>" />
+			<img src="<?php echo esc_url( $attachment_src[0] ); ?>" class="mobile" width="<?php echo esc_attr( round( $attachment_src[1] / 4 ) ); ?>" height="<?php echo esc_attr( round( $attachment_src[2] / 4 ) ); ?>" alt="<?php echo esc_attr( $company ); ?>" />
 		</div>
 		<?php
 	}
@@ -262,9 +260,15 @@ function wcdn_pdf_company_logo( $ttype ) {
 		$typei          = pathinfo( $attachment_src[0], PATHINFO_EXTENSION );
 		$data           = file_get_contents( $attachment_src[0] );
 		$data_uri       = 'data:image/' . $typei . ';base64,' . base64_encode( $data );
-		?>
-		<img src="<?php echo $data_uri; // phpcs:ignore ?>" width="<?php echo esc_attr( $sizew ); ?>px" height="<?php echo esc_attr( $sizeh ); ?>px" alt="<?php echo esc_attr( $company ); ?>" /> 
-		<?php
+		if ( 'default' === $ttype ) {
+			?>
+			<img src="<?php echo esc_url( $attachment_src[0] ); ?>"  class="desktop"  width="<?php echo esc_attr( round( $attachment_src[1] / 4 ) ); ?>" height="<?php echo esc_attr( round( $attachment_src[2] / 4 ) ); ?>" alt="<?php echo esc_attr( $company ); ?>" />
+			<?php
+		} else {
+			?>
+			<img src="<?php echo $data_uri; // phpcs:ignore ?>" width="<?php echo esc_attr( $sizew ); ?>px" height="<?php echo esc_attr( $sizeh ); ?>px" alt="<?php echo esc_attr( $company ); ?>" />
+			<?php
+		}
 	}
 }
 

--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -15,8 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="company-logo">
 			<?php
 			if ( wcdn_get_company_logo_id() ) :
-				?>
-				<?php wcdn_company_logo(); ?><?php endif; ?>
+				$template_save = get_option( 'wcdn_template_type' );
+				if ( 'default' === $template_save ) {
+					wcdn_company_logo();
+				} elseif ( 'simple' === $template_save ) {
+					wcdn_pdf_company_logo( $ttype = 'simple' );
+				}
+			endif;
+			?>
 		</div>
 
 		<div class="company-info">


### PR DESCRIPTION
1. remove logo size for  the default template.
2. Set payment date in live preview. when the payment date is not there in last order it is showing order date.
3. Fix space issue for invoice and receipt. [https://prnt.sc/scn5trkGLsgT](https://prnt.sc/scn5trkGLsgT)
4. in simple template live preview the invoice number is not showing when the last order has no invoice number . so i have added Next number in to that. with the condition. if invoice number is not present in last order it wil show the next number of numbering setting.