### PR TITLE
remove store time

### DIFF
--- a/includes/wcdn-template-functions.php
+++ b/includes/wcdn-template-functions.php
@@ -424,7 +424,7 @@ function wcdn_get_order_info( $order, $type = '' ) {
 		}
 		$fields['order_date'] = array(
 			'label'       => __( $label, 'woocommerce-delivery-notes' ), // phpcs:ignore
-			'value'       => date_i18n( get_option( 'date_format' ), strtotime( $wdn_order_order_date ) ),
+			'value'       => date_i18n( get_option( 'date_format' ), $wdn_order_order_date ),
 			'font-size'   => $data['order_date']['order_date_font_size'],
 			'font-weight' => $data['order_date']['order_date_style'],
 			'color'       => $data['order_date']['order_date_text_colour'],


### PR DESCRIPTION
remove store time the year format will not properly showing in order date. [https://prnt.sc/hovWqe9zrGw_](https://prnt.sc/hovWqe9zrGw_)
$wdn_order_order_date is already a timestamp, there's no need to use strtotime on it so i have remove it.