### PR TITLE
Fix #370 added wcdn_head hook in PDF template.

### DIFF
--- a/templates/pdf/default/deliverynote/template.php
+++ b/templates/pdf/default/deliverynote/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>

--- a/templates/pdf/default/invoice/template.php
+++ b/templates/pdf/default/invoice/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>

--- a/templates/pdf/default/receipt/template.php
+++ b/templates/pdf/default/receipt/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>

--- a/templates/pdf/simple/deliverynote/template.php
+++ b/templates/pdf/simple/deliverynote/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>

--- a/templates/pdf/simple/invoice/template.php
+++ b/templates/pdf/simple/invoice/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>

--- a/templates/pdf/simple/receipt/template.php
+++ b/templates/pdf/simple/receipt/template.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
 	<head>
 	<?php
+	do_action( 'wcdn_head', wcdn_get_template_type() );
 	wcdn_rtl();
 	?>
 	</head>


### PR DESCRIPTION
Fix #370 added wcdn_head hook in the PDF default & simple both templates. This hook will not added to the live preview because we are not going to directly apply a style tag in the live preview due to the vue.js implementation. It will show an error if we add a style tag to this.