### PR TITLE
Fix admin.js loading error on order edit and listing pages

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -172,7 +172,7 @@ jQuery(document).ready(function($) {
 			targetCondition = '#ct_acc_1_content';
 		}
 	
-		if (admin_object.template_save === 'default' && targetCondition) {
+		if (typeof admin_object !== 'undefined' && admin_object.template_save === 'default' && targetCondition) {
 			$('.accordion-button').each(function() {
 				var target = $(this).attr('data-bs-target');
 				if (target !== targetCondition) {
@@ -234,7 +234,7 @@ jQuery(document).ready(function($) {
 
 	//Set checkbox on and off when default template is selected.
 	$(document).ready(function() {
-		if (admin_object.template_save === 'default') {
+		if (typeof admin_object !== 'undefined' && admin_object.template_save === 'default') {
 			var documentTypeElement = document.querySelector('#document_type');
 			var document_type = documentTypeElement ? documentTypeElement.value : null;
 			var checkboxes = document.querySelectorAll('.custom-checkbox');

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -306,7 +306,9 @@ jQuery(document).ready(function($) {
 		}
 	});
 
-	$('[data-toggle="tooltip"]').tooltip();
+	if (typeof $.fn.tooltip === 'function') {
+		$('[data-toggle="tooltip"]').tooltip();
+	}
 	
 	var footer = jQuery(".wcdn-footer-top").html();
 	jQuery("#mainform").append( footer );


### PR DESCRIPTION
This pull request fixes an error that occurred when loading the [admin.js](https://github.com/TycheSoftwares/woocommerce-delivery-notes/blob/461fcef3bf3c3ff267a98c402cc0d2a8226ada30/includes/class-wcdn-writepanel.php#L67) script on WooCommerce order edit and listing pages. The error happened because the wp_localize_script for the woocommerce-delivery-notes-admin script was not triggered on these pages, resulting in the absence of the  #admin_object.

Also, a conditional check was added to the tooltip function.

Error reported in: [https://wordpress.org/support/topic/order-printing-tab-wont-display-any-buttons-on-order-page-in-backend/](https://wordpress.org/support/topic/order-printing-tab-wont-display-any-buttons-on-order-page-in-backend/)

Enhancements:

* Added a check to ensure `admin_object` is defined before accessing its `template_save` property in two places. (`assets/js/admin.js`, [[1]](diffhunk://#diff-9a7989c18ea861638681ec9c56a3f8d62347c0483f1889e194ce4a1d2d603894L175-R175) [[2]](diffhunk://#diff-9a7989c18ea861638681ec9c56a3f8d62347c0483f1889e194ce4a1d2d603894L237-R237)
* Added a check to ensure the jQuery `tooltip` function is defined before initializing tooltips. (`assets/js/admin.js`, [assets/js/admin.jsR309-R311](diffhunk://#diff-9a7989c18ea861638681ec9c56a3f8d62347c0483f1889e194ce4a1d2d603894R309-R311))