### PR TITLE
Fix #385 prints buttons are not showing

### DIFF
--- a/includes/class-woocommerce-delivery-notes.php
+++ b/includes/class-woocommerce-delivery-notes.php
@@ -363,6 +363,19 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 		 * Install or update the default settings.
 		 */
 		public function update() {
+			// Set default template type for invoice, receipt, and delivery-note if not set.
+			if ( false === get_option( 'wcdn_template_type_invoice', false ) ) {
+				add_option( 'wcdn_template_type_invoice', 'yes' );
+			}
+			if ( false === get_option( 'wcdn_template_type_receipt', false ) ) {
+				add_option( 'wcdn_template_type_receipt', 'yes' );
+			}
+			if ( false === get_option( 'wcdn_template_type_delivery_note', false ) ) {
+				add_option( 'wcdn_template_type_delivery-note', 'yes' );
+			}
+			if ( false === get_option( 'wcdn_print_order_page_endpoint', false ) ) {
+				add_option( 'wcdn_print_order_page_endpoint', 'print-order' );
+			}
 			$option_version = get_option( 'wcdn_version', '1' );
 			if ( isset( $_FILES['shop_logo'] ) && ! empty( $_FILES['shop_logo'] ) ) {
 				$upload = wp_handle_upload(


### PR DESCRIPTION
Fix #385 prints buttons are not showing on order edit page. the issue is for fresh instalments, the fields database is not there in DB table so it is not appearing.