### PR TITLE
To improve customizability of the need login message

### DIFF
--- a/includes/class-wcdn-print.php
+++ b/includes/class-wcdn-print.php
@@ -605,9 +605,9 @@ if ( ! class_exists( 'WCDN_Print' ) ) {
 						$redirect_url = home_url();
 					}
 					if ( isset( $_GET['need_login_message'] ) && $_GET['need_login_message'] === 'true' ) { // phpcs:ignore
-						echo '<div class="notice notice-info"><p>' . __( 'You need to be logged into your account to access the Invoice. Please login first.' ) . '</p></div>'; // phpcs:ignore
+						echo '<div class="notice notice-info"><p>' . __( 'You need to be logged into your account to access the Invoice. Please login first.', 'woocommerce-delivery-notes' ) . '</p></div>'; // phpcs:ignore
 						// Display a confirmation button to redirect the user to the login page.
-						echo '<a href="' . wp_login_url( $redirect_url ) . '" class="button">Proceed to Login</a>'; // phpcs:ignore
+						echo '<a href="' . wp_login_url( $redirect_url ) . '" class="button">' . __( 'Proceed to Login', 'woocommerce-delivery-notes' ) . '</a>'; // phpcs:ignore
 						exit;
 					} else {
 						wp_safe_redirect( add_query_arg( 'need_login_message', 'true', $redirect_url ) );


### PR DESCRIPTION
When visiting a different customer's invoice, the following messages are displayed and they are not very easy to change.

```
You need to be logged into your account to access the Invoice. Please login first.

Proceed to Login
```

![capture1](https://github.com/user-attachments/assets/203942f7-ed01-40b3-979b-4e4e78e255ff)

So, I would like to make it better to customize these messages through the i18n feature of WordPress.

Thank you.