### PR TITLE
Add support for HPOS order status bulk order filtering

### DIFF
--- a/includes/class-wcdn-writepanel.php
+++ b/includes/class-wcdn-writepanel.php
@@ -181,6 +181,10 @@ if ( ! class_exists( 'WCDN_Writepanel' ) ) {
 			if ( isset( $referer_args['post_status'] ) ) {
 				$args = wp_parse_args( array( 'post_status' => $referer_args['post_status'] ), $args );
 			}
+			// support HPOS order status
+			if ( isset( $referer_args['status'] ) ) {
+				$args = wp_parse_args( array( 'status' => $referer_args['status'] ), $args );
+			}
 			if ( isset( $referer_args['paged'] ) ) {
 				$args = wp_parse_args( array( 'paged' => $referer_args['paged'] ), $args );
 			}


### PR DESCRIPTION
HPOS orders uses 'status', not 'post_status' to filter orders by order status. Adding this filter ensures the filtering does not reset to 'All' when doing a bulk order print when in filtering by order status.