### PR TITLE
Fix #436 added filter to change the labels for default template.

### DIFF
--- a/includes/admin/views/Preview_template/default-preview-template.php
+++ b/includes/admin/views/Preview_template/default-preview-template.php
@@ -308,7 +308,7 @@ if ( is_null( $parent_order ) ) {
 				if ( $totals_arr ) :
 
 					foreach ( $totals_arr as $total ) :
-						$modified_label = apply_filters( 'custom_order_total_label', $total['label'], $key, $order );
+						$modified_label = apply_filters( 'wcdn_invoice_order_total_label', $total['label'], $key, $order );
 						?>
 						<tr>
 							<td class="total-name"><span><?php echo wp_kses_post( $modified_label ); ?></span></td>

--- a/templates/pdf/default/deliverynote/template.php
+++ b/templates/pdf/default/deliverynote/template.php
@@ -147,7 +147,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						if ( $totals_arr ) :
 
 							foreach ( $totals_arr as $total ) :
-								$modified_label = apply_filters( 'custom_order_total_label', $total['label'], $key, $order );
+								$modified_label = apply_filters( 'wcdn_invoice_order_total_label', $total['label'], $key, $order );
 								?>
 								<tr>
 									<td class="total-name"><span><?php echo wp_kses_post( $modified_label ); ?></span></td>

--- a/templates/pdf/default/invoice/template.php
+++ b/templates/pdf/default/invoice/template.php
@@ -148,7 +148,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						if ( $totals_arr ) :
 
 							foreach ( $totals_arr as $total ) :
-								$modified_label = apply_filters( 'custom_order_total_label', $total['label'], $key, $order );
+								$modified_label = apply_filters( 'wcdn_invoice_order_total_label', $total['label'], $key, $order );
 								?>
 								<tr>
 									<td class="total-name"><span><?php echo wp_kses_post( $modified_label ); ?></span></td>

--- a/templates/pdf/default/receipt/template.php
+++ b/templates/pdf/default/receipt/template.php
@@ -148,7 +148,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						if ( $totals_arr ) :
 
 							foreach ( $totals_arr as $total ) :
-								$modified_label = apply_filters( 'custom_order_total_label', $total['label'], $key, $order );
+								$modified_label = apply_filters( 'wcdn_invoice_order_total_label', $total['label'], $key, $order );
 								?>
 								<tr>
 									<td class="total-name"><span><?php echo wp_kses_post( $modified_label ); ?></span></td>

--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -265,7 +265,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				if ( $totals_arr ) :
 
 					foreach ( $totals_arr as $total ) :
-						$modified_label = apply_filters( 'custom_order_total_label', $total['label'], $key, $order );
+						$modified_label = apply_filters( 'wcdn_invoice_order_total_label', $total['label'], $key, $order );
 						?>
 						<tr>
 							<td class="total-name"><span><?php echo wp_kses_post( $modified_label ); ?></span></td>


### PR DESCRIPTION
Fix #436 added filter to change the labels for default template.

```
function custom_translate_order_total_labels( $label, $order ) {
    // Define custom labels without translation
    $custom_labels = array(
        'Subtotal' => 'Product Subtotal',    // Subtotal
        'Shipping' => 'Shipping Charges',    // Shipping
        'Total'    => 'Final Amount',        // Total
    );

    // Return the custom label if it exists, otherwise return the default label
    return isset( $custom_labels[ $label ] ) ? $custom_labels[ $label ] : $label;
}
add_filter( 'wcdn_invoice_order_total_label', 'custom_translate_order_total_labels', 10, 3 );
```
