### PR TITLE
Fix #456 YITH WooCommerce Product Add-Ons meta key is showing in addon.

### DIFF
--- a/includes/admin/views/Preview_template/default-preview-template.php
+++ b/includes/admin/views/Preview_template/default-preview-template.php
@@ -209,6 +209,42 @@ if ( is_null( $parent_order ) ) {
 											$product_addons = WC_Product_Addons_Helper::get_product_addons( $product_id );
 										}
 									}
+									// --- handle YITH add-ons: print labels and remove raw ywapo-* meta to avoid duplicates ---
+									$yith_addon_meta_map = array();
+									if ( isset( $item_meta_fields['_ywapo_meta_data'] ) && is_array( $item_meta_fields['_ywapo_meta_data'] ) ) {
+										foreach ( $item_meta_fields['_ywapo_meta_data'] as $group ) {
+											if ( ! is_array( $group ) ) {
+												continue;
+											}
+											foreach ( (array) $group as $maybe ) {
+												if ( isset( $maybe['addon_id'] ) ) {
+													$option_id                        = isset( $maybe['option_id'] ) ? $maybe['option_id'] : 0;
+													$meta_key                         = 'ywapo-addon-' . $maybe['addon_id'] . '-' . $option_id;
+													$yith_addon_meta_map[ $meta_key ] = $maybe;
+												} else {
+													foreach ( (array) $maybe as $sub ) {
+														if ( isset( $sub['addon_id'] ) ) {
+															$option_id                        = isset( $sub['option_id'] ) ? $sub['option_id'] : 0;
+															$meta_key                         = 'ywapo-addon-' . $sub['addon_id'] . '-' . $option_id;
+															$yith_addon_meta_map[ $meta_key ] = $sub;
+														}
+													}
+												}
+											}
+										}
+										foreach ( $yith_addon_meta_map as $meta_key => $addon ) {
+											if ( isset( $addon['display_label'] ) && isset( $addon['display_value'] ) ) {
+												echo '<br><strong>' . esc_html( $addon['display_label'] ) . ' : </strong>' . wp_kses_post( $addon['display_value'] );
+											} else {
+												if ( isset( $item_meta_fields[ $meta_key ] ) ) {
+													echo '<br><strong>' . esc_html( $meta_key ) . ' : </strong>' . wp_kses_post( $item_meta_fields[ $meta_key ] );
+												}
+											}
+											if ( isset( $item_meta_fields[ $meta_key ] ) ) {
+												unset( $item_meta_fields[ $meta_key ] );
+											}
+										}
+									} // --- end handle YITH add-ons ---
 									if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 										if ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] ) {
 											$variation = wc_get_product( $item['product_id'] );

--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -166,6 +166,42 @@ if ( ! defined( 'ABSPATH' ) ) {
 											$product_addons = WC_Product_Addons_Helper::get_product_addons( $product_id );
 										}
 									}
+									// --- handle YITH add-ons: print labels and remove raw ywapo-* meta to avoid duplicates ---
+									$yith_addon_meta_map = array();
+									if ( isset( $item_meta_fields['_ywapo_meta_data'] ) && is_array( $item_meta_fields['_ywapo_meta_data'] ) ) {
+										foreach ( $item_meta_fields['_ywapo_meta_data'] as $group ) {
+											if ( ! is_array( $group ) ) {
+												continue;
+											}
+											foreach ( (array) $group as $maybe ) {
+												if ( isset( $maybe['addon_id'] ) ) {
+													$option_id                        = isset( $maybe['option_id'] ) ? $maybe['option_id'] : 0;
+													$meta_key                         = 'ywapo-addon-' . $maybe['addon_id'] . '-' . $option_id;
+													$yith_addon_meta_map[ $meta_key ] = $maybe;
+												} else {
+													foreach ( (array) $maybe as $sub ) {
+														if ( isset( $sub['addon_id'] ) ) {
+															$option_id                        = isset( $sub['option_id'] ) ? $sub['option_id'] : 0;
+															$meta_key                         = 'ywapo-addon-' . $sub['addon_id'] . '-' . $option_id;
+															$yith_addon_meta_map[ $meta_key ] = $sub;
+														}
+													}
+												}
+											}
+										}
+										foreach ( $yith_addon_meta_map as $meta_key => $addon ) {
+											if ( isset( $addon['display_label'] ) && isset( $addon['display_value'] ) ) {
+												echo '<br><strong>' . esc_html( $addon['display_label'] ) . ' : </strong>' . wp_kses_post( $addon['display_value'] );
+											} else {
+												if ( isset( $item_meta_fields[ $meta_key ] ) ) {
+													echo '<br><strong>' . esc_html( $meta_key ) . ' : </strong>' . wp_kses_post( $item_meta_fields[ $meta_key ] );
+												}
+											}
+											if ( isset( $item_meta_fields[ $meta_key ] ) ) {
+												unset( $item_meta_fields[ $meta_key ] );
+											}
+										}
+									} // --- end handle YITH add-ons ---
 									if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 										if ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] ) {
 											$variation = wc_get_product( $item['product_id'] );


### PR DESCRIPTION
Fix #456 YITH WooCommerce Product Add-Ons meta key is showing in addon.

Added handling for YITH add-ons to display labels/values properly in print templates.
Implemented cleanup to remove raw ywapo-* meta fields and avoid duplicate outputs.