### PR TITLE
Fix #457 The additional options created from the 'Extra Product Options & Add-Ons for WooCommerce' plugin is not showing on the Invoice/Delivery Notes/ Receipt templates.

### DIFF
--- a/includes/admin/views/Preview_template/default-preview-template.php
+++ b/includes/admin/views/Preview_template/default-preview-template.php
@@ -209,6 +209,15 @@ if ( is_null( $parent_order ) ) {
 											$product_addons = WC_Product_Addons_Helper::get_product_addons( $product_id );
 										}
 									}
+									// Extra Product Options (ThemeComplete EPO) support.
+									$epo_data = $item->get_meta( '_tmcartepo_data', true );
+									if ( ! empty( $epo_data ) && is_array( $epo_data ) ) {
+										foreach ( $epo_data as $epo ) {
+											if ( ! empty( $epo['name'] ) && isset( $epo['value'] ) ) {
+												echo '<br>' . wp_kses_post( '<strong>' . $epo['name'] . ' : </strong>' . $epo['value'] );
+											}
+										}
+									}
 									if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 										if ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] ) {
 											$variation = wc_get_product( $item['product_id'] );

--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -166,6 +166,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 											$product_addons = WC_Product_Addons_Helper::get_product_addons( $product_id );
 										}
 									}
+									// Extra Product Options (ThemeComplete EPO) support.
+									$epo_data = $item->get_meta( '_tmcartepo_data', true );
+									if ( ! empty( $epo_data ) && is_array( $epo_data ) ) {
+										foreach ( $epo_data as $epo ) {
+											if ( ! empty( $epo['name'] ) && isset( $epo['value'] ) ) {
+												echo '<br>' . wp_kses_post( '<strong>' . $epo['name'] . ' : </strong>' . $epo['value'] );
+											}
+										}
+									}
 									if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 										if ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] ) {
 											$variation = wc_get_product( $item['product_id'] );


### PR DESCRIPTION
Fix #457 The additional options created from the 'Extra Product Options & Add-Ons for WooCommerce' plugin is not showing on the Invoice/Delivery Notes/ Receipt templates.

Cause: Extra options from the ThemeComplete EPO plugin were not being displayed in invoice/delivery note templates.
Fix: Added support to fetch and render _tmcartepo_data so EPO add-ons show correctly.