### PR TITLE
Fix #455 Fatal error thrown on the Template page.

### DIFF
--- a/includes/admin/views/Preview_template/default-preview-template.php
+++ b/includes/admin/views/Preview_template/default-preview-template.php
@@ -35,6 +35,17 @@ if ( is_null( $parent_order ) ) {
 	echo '<div class="notices">No WooCommerce orders found! Please consider adding your first order to see this preview.</div>';
 	return;
 }
+// Ensure we always have a valid WC_Order object.
+if ( ! ( $parent_order instanceof WC_Order ) ) {
+	echo '<div class="notices">';
+	esc_html_e(
+		'No valid WooCommerce order found! Please create an order to preview this template.',
+		'woocommerce-delivery-notes'
+	);
+	echo '</div>';
+	return;
+}
+$order = $parent_order; //phpcs:ignore
 ?>
 
 	<div class="order-brandings">


### PR DESCRIPTION
Fix #455 Fatal error thrown on the Template page.

Cause:
A fatal error occurred when an order was archived, and the preview template fetched the last order ID.

Fix:
Added a condition to ensure a valid WC_Order object is always available.

**Testing Note**: Please verify the preview template for refund orders and for fresh installations with no orders.
The issue reproduces only when orders are archived and the plugin is installed, and the template settings page is opened without making any changes.