### PR TITLE
Replace Vue.js CDN link with local asset URL

### DIFF
--- a/includes/class-wcdn-writepanel.php
+++ b/includes/class-wcdn-writepanel.php
@@ -210,7 +210,7 @@ if ( ! class_exists( 'WCDN_Writepanel' ) ) {
 					</div>
 				</div>
 			</div>
-			<script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+			<script src="<?php echo esc_url( WooCommerce_Delivery_Notes::$plugin_url . 'assets/js/vue.js' ); ?>"></script>
 			<script>
 				document.addEventListener("DOMContentLoaded", function() {
 					new Vue({


### PR DESCRIPTION
**Problem:**
The bulk print modal in `includes/class-wcdn-writepanel.php` was loading Vue.js via a hardcoded script tag pointing to `cdn.jsdelivr.net`.
This causes the feature to break on sites with strict Content Security Policies (CSP) that don't allow external script sources, and introduces an unneccessary external dependency.

**Solution:**
I replaced the hardcoded jsDelivr link with local `assets/js/vue.js`, already included in the plugin. I used `WooCommerce_Delivery_Notes::$plugin_url` to construct the path, ensuring consistency with how other assets are loaded in the plugin.

**Changes:**
- `includes/class-wcdn-writepanel.php`: Replaced external CDN script tag with local asset enqueue.

**Testing:**
- Validated that the bulk print modal opens and functions correctly.
- Confirmed that no external request to `jsdelivr.net` is made when the modal is triggered.