### PR TITLE
Fix #484 getting Fatal error: Uncaught TypeError.

### DIFF
--- a/includes/class-wcdn-settings.php
+++ b/includes/class-wcdn-settings.php
@@ -199,6 +199,9 @@ if ( ! class_exists( 'WCDN_Settings' ) ) {
 			);
 
 			foreach ( $invoice_defaults as $parent_key => $invoice_default_values ) {
+				if ( ! isset( $invoice_data[ $parent_key ] ) || ! is_array( $invoice_data[ $parent_key ] ) ) {
+					$invoice_data[ $parent_key ] = array();
+				}
 				foreach ( $invoice_default_values as $key => $invoice_default_value ) {
 					if ( ! isset( $invoice_data[ $parent_key ][ $key ] ) || empty( $invoice_data[ $parent_key ][ $key ] ) ) {
 						$invoice_data[ $parent_key ][ $key ] = $invoice_default_value;


### PR DESCRIPTION
Fix #484 getting Fatal error: Uncaught TypeError.

Cause: $invoice_data[$parent_key] was sometimes stored as a string, causing a PHP 8+ fatal error when accessing array offsets.

Fix: Added a check to ensure $invoice_data[$parent_key] is always an array before assigning default values.