### PR TITLE
Fix fatal error by conditionally loading Dompdf autoloader when class is missing

### DIFF
--- a/includes/front/wcdn-front-function.php
+++ b/includes/front/wcdn-front-function.php
@@ -31,6 +31,13 @@ function create_pdf( $order, $type ) {
 	// Get order id from the order object.
 	$order_id = $order->get_id();
 
+	if ( ! class_exists( '\Dompdf\Options' ) ) {
+		$autoload = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+		if ( file_exists( $autoload ) ) {
+			require_once $autoload;
+		}
+	}
+
 	// Instantiate and use the dompdf class.
 	$options = new \Dompdf\Options();
 	$options->set( 'isRemoteEnabled', true );


### PR DESCRIPTION
This PR prevents a checkout critical error caused by the Dompdf\Options class not being found during PDF generation.

Fix #495