### PR TITLE
Fix #498 #415 Blank page issue with Print link in a different browser when using "+" sign in email.

### DIFF
--- a/includes/class-wcdn-print.php
+++ b/includes/class-wcdn-print.php
@@ -501,7 +501,7 @@ if ( ! class_exists( 'WCDN_Print' ) ) {
 
 			// Set the email arg.
 			if ( ! empty( $order_email ) ) {
-				$args = wp_parse_args( array( 'print-order-email' => $order_email ), $args );
+				$args = wp_parse_args( array( 'print-order-email' => rawurlencode( $order_email ) ), $args );
 			}
 
 			// Generate the url.


### PR DESCRIPTION
Fix #498 #415 Blank page issue with Print link in a different browser when using "+" sign in email.

Cause: The order email parameter was passed without encoding, which caused the URL to break for emails containing special characters like '+'.
Fix: Applied rawurlencode() to the email parameter before adding it to the URL.