### PR TITLE
Fatal error displayed when hpos disabled

### DIFF
--- a/includes/admin/class-backend.php
+++ b/includes/admin/class-backend.php
@@ -187,7 +187,7 @@ class Backend {
 	public function create_box_content( $post ) {
 		global $post_id;
 
-		$order_id = ( $post instanceof WP_Post ) ? $post->ID : $post->get_id();
+		$order_id = ( $post instanceof \WP_Post ) ? $post->ID : $post->get_id();
 		$order    = wc_get_order( $order_id );
 
 		if ( ! $order || $order instanceof \WC_Order_Refund ) {


### PR DESCRIPTION
When HPOS is disabled in WooCommerce, orders are represented as WP_Post objects instead of WC_Order.

A fatal error was occurring on the Edit Order page due to an incorrect instanceof check:

$post instanceof WP_Post

Since the plugin uses PHP namespaces, this condition was resolving to a namespaced class (Tyche\WCDN\WP_Post) instead of the global WP_Post class provided by WordPress. As a result, the check failed even when $post was a valid WP_Post object, leading to a call to an undefined method (get_id()).

Fix #555 