### PR TITLE
Print actions were not displayed for custom statuses

### DIFF
--- a/includes/helpers/class-utils.php
+++ b/includes/helpers/class-utils.php
@@ -511,7 +511,7 @@ class Utils {
 		}
 
 		// Invoice.
-		if ( in_array( $status, array( 'pending', 'on-hold', 'processing', 'completed' ), true ) ) {
+		if ( ! in_array( $status, array( 'failed', 'cancelled', 'refunded' ), true ) ) {
 			$types[] = 'invoice';
 		}
 
@@ -526,7 +526,7 @@ class Utils {
 			$types[] = 'packingslip';
 
 			// Optional: stricter delivery note logic.
-			if ( in_array( $status, array( 'processing', 'completed' ), true ) ) {
+			if ( $order->is_paid() ) {
 				$types[] = 'deliverynote';
 			}
 		}


### PR DESCRIPTION
We displayed Invoice only for status - Pending, On hold, Processing & Completed. Due to this the Invoice was not displayed for custom statuses. Instead of check these statuses, we are now checking if Order is not Failed or Cancelled or Refunded and display Invoice for other statuses.

Receipt - We display receipt only for paid orders. If the custom order status setting 'Mark as Paid' is enabled, the Print Receipt button will be displayed.

Delivery Note - We checked if the product is a physical product and status should be Processing or Completed to display this action. Fixed it such that we check if it is a physical product and the order is marked as paid to display Print Delivery Note.

If any customer wants to display the buttons for all statuses, we can use the filter wcdn_template_types_from_order.

```
add_filter( 'wcdn_template_types_from_order', 'wcdn_template_types_from_order', 10, 2 );
function wcdn_template_types_from_order(  $types, $order ) {
     $types = array( 'invoice', 'receipt', 'packingslip', 'deliverynote', 'creditnote' );
     return $types;
}
```