### PR TITLE
Update github action to consider build files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
 
       - name: Run release build
-        run: npm run release
+        run: npm run release:svn
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,12 @@ name: Deploy to WordPress.org
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"  # matches 1.0.0, 2.0.0, 1.5.2 etc. Ignores 1.0.0-beta, 1.0.0-rc1 etc.
+
+concurrency:
+  group: wp-org-deploy
+  cancel-in-progress: false  # let the running deploy finish; don't cancel it mid-SVN-commit
+
 jobs:
   build-and-deploy:
     name: Build & WordPress.org Release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,38 @@ name: Deploy to WordPress.org
 on:
   push:
     tags:
-    - "*"
+      - "*"
 jobs:
-  tag:
-    name: WordPress.org Release
+  build-and-deploy:
+    name: Build & WordPress.org Release
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@master
-    - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SLUG: woocommerce-delivery-notes # optional, remove if GitHub repo name matches SVN slug, including capitalization
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Setup PHP & Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: composer
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run release build
+        run: npm run release
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: woocommerce-delivery-notes
+          BUILD_DIR: dist/woocommerce-delivery-notes

--- a/build-plugin.js
+++ b/build-plugin.js
@@ -8,8 +8,15 @@ const cssnano = require("cssnano");
 const PLUGIN_SLUG = "woocommerce-delivery-notes";
 const pluginHeader = fs.readFileSync(`${PLUGIN_SLUG}.php`, "utf8");
 const version = (pluginHeader.match(/\*\s+Version:\s+(\S+)/) ?? [])[1] ?? "0.0.0";
-const variant = process.argv.includes("--variant=wc") ? "wc" : "non-wc";
-const DEST_BASE = path.join("dist", variant === "wc" ? "wc-version" : "non-wc-version");
+const variant = process.argv.includes("--variant=wc")
+    ? "wc"
+    : process.argv.includes("--variant=svn")
+        ? "svn"
+        : "non-wc";
+
+const DEST_BASE = variant === "svn"
+    ? "dist"
+    : path.join("dist", variant === "wc" ? "wc-version" : "non-wc-version");
 const DEST = path.join(DEST_BASE, PLUGIN_SLUG);
 const ZIP_PATH = path.join(DEST_BASE, `${PLUGIN_SLUG}.${version}.zip`);
 
@@ -55,10 +62,11 @@ if (!fs.existsSync("vendor")) {
 }
 
 // Clean only this variant's output folder (leaves the other variant intact).
-fs.removeSync(DEST_BASE);
+fs.removeSync(variant === "svn" ? DEST : DEST_BASE);
 fs.mkdirpSync(DEST);
 
-console.log(`\nPackaging ${variant === "wc" ? "WC Marketplace" : "Standard"} version…`);
+const variantLabel = variant === "wc" ? "WC Marketplace" : variant === "svn" ? "SVN" : "Standard";
+console.log(`\nPackaging ${variantLabel} version…`);
 
 // Copy all included files.
 INCLUDE.forEach((item) => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "package:wc": "node build-plugin.js --variant=wc",
         "release:non-wc": "npm run build && node build-plugin.js",
         "release:wc": "WCDN_WC_BUILD=true npm run build && node build-plugin.js --variant=wc",
-        "release": "npm run clean && npm run composer && npm run release:non-wc && npm run release:wc"
+        "release": "npm run clean && npm run composer && npm run release:non-wc && npm run release:wc",
+        "release:svn": "npm run clean && npm run build && npm run i18n && node build-plugin.js --variant=svn"
     },
     "devDependencies": {
         "@wordpress/eslint-plugin": "^22.22.0",


### PR DESCRIPTION
Updated the github action to run the build commands and consider the plugin folder from 'dist/' folder instead of the master copy

Node setup — installs Node 20 with npm cache for faster runs.
PHP + Composer setup — your release script runs composer install, so PHP needs to be available in the CI environment.
npm ci — installs exact versions from package-lock.json, more reliable than npm install in CI.
npm run release — runs your full build pipeline (clean → composer → release:non-wc → release:wc).
BUILD_DIR: dist — this is the critical part. It tells the 10up deploy action to use your built dist/ folder instead of the repo root.