### PR TITLE
fix #608 WooCommerce Checkout Add-Ons values are not displayed in generated invoices/documents.

### DIFF
--- a/includes/api/class-templates.php
+++ b/includes/api/class-templates.php
@@ -617,8 +617,16 @@ class Templates extends \Tyche\WCDN\Api\Api {
 				if ( 0.0 === $fee_total ) {
 					continue;
 				}
+				$label        = $fee->get_name();
+				$addon_labels = $fee->get_meta( '_wc_checkout_add_on_label', true ); // Support WooCommerce Checkout Add-Ons label.
+				if ( ! empty( $addon_labels ) ) {
+					if ( is_array( $addon_labels ) ) {
+						$addon_labels = implode( ', ', $addon_labels );
+					}
+					$label .= ': ' . $addon_labels;
+				}
 				$fee_lines[] = array(
-					'label' => $fee->get_name(),
+					'label' => $label,
 					'value' => wc_price( $fee_total, array( 'currency' => $currency ) ),
 				);
 			}


### PR DESCRIPTION
fix #608 WooCommerce Checkout Add-Ons values are not displayed in generated invoices/documents.

Cause: SkyVerge Checkout Add-Ons stores selected option values in fee item meta (_wc_checkout_add_on_label), but WCDN was only displaying the fee name and amount in invoice totals.

Fix: Retrieve and append the SkyVerge add-on labels from fee item meta to the fee label before rendering invoice total rows.
				