### PR TITLE
Fix #607 Logo Scaling Not Applied in Generated Documents.

### DIFF
--- a/templates/css/pdf/style.css
+++ b/templates/css/pdf/style.css
@@ -76,7 +76,6 @@ th {
 }
 
 .wcdn-logo img {
-    max-height: 90pt;
     width: auto;
 }
 

--- a/templates/css/style.css
+++ b/templates/css/style.css
@@ -40,7 +40,6 @@ hr {
 }
 
 .wcdn-logo img {
-    max-height: 80px;
     width: auto;
 }
 


### PR DESCRIPTION
Fix #607 Logo Scaling Not Applied in Generated Documents.

FIX - Remove max-height from wcdn-logo img class. It is causing the image to apply the scale size from the setting.