### PR TITLE
Fix #606 Packing Slip PDF Not Attached to Admin Email.

### DIFF
--- a/includes/integrations/class-emails.php
+++ b/includes/integrations/class-emails.php
@@ -210,7 +210,8 @@ class Emails {
 			}
 		}
 
-		$already_sent = $order->get_meta( '_email_pdf_sent', true );
+		// Prevent duplicate emails for the same template.
+		$already_sent = $order->get_meta( '_email_pdf_sent_' . $template, true );
 
 		if ( $already_sent || empty( $emails ) || empty( $file_path ) || ! file_exists( $file_path ) || '' === $emails ) {
 			return;
@@ -274,7 +275,7 @@ class Emails {
 			array( $file_path )
 		);
 
-		$order->update_meta_data( '_email_pdf_sent', 1 );
+		$order->update_meta_data( '_email_pdf_sent_' . $template, 1 );
 		$order->save();
 	}
 


### PR DESCRIPTION
Fix #606 Packing Slip PDF Not Attached to Admin Email.

Cause: A metadata flag was added to prevent duplicate PDF attachments, but it was not template-specific. As a result, once an attachment was sent for one email template, attachments for other templates were also skipped.

Fix: Updated the metadata check to be template-specific, ensuring that attachment tracking is handled separately for each email template and allowing the Packing Slip PDF to be attached correctly to admin emails.