### PR TITLE
Fix #614 #606 Email Attachments Not Sent Consistently When Multiple Document Templates Are Enabled.

### DIFF
--- a/includes/integrations/class-emails.php
+++ b/includes/integrations/class-emails.php
@@ -210,7 +210,7 @@ class Emails {
 			}
 		}
 
-		$already_sent = $order->get_meta( '_email_pdf_sent', true );
+		$already_sent = $order->get_meta( '_email_pdf_sent_' . $template, true );
 
 		if ( $already_sent || empty( $emails ) || empty( $file_path ) || ! file_exists( $file_path ) || '' === $emails ) {
 			return;
@@ -274,7 +274,7 @@ class Emails {
 			array( $file_path )
 		);
 
-		$order->update_meta_data( '_email_pdf_sent', 1 );
+		$order->update_meta_data( '_email_pdf_sent_' . $template, 1 );
 		$order->save();
 	}
 


### PR DESCRIPTION
Fix #614 #606 Email Attachments Not Sent Consistently When Multiple Document Templates Are Enabled.

Cause: A global flag was being set to prevent duplicate email sending for an order. As a result, when one attachment template was processed, it unintentionally blocked attachments from other templates as well.

Fix: Added a per-template flag so that each template is tracked independently, preventing one template from blocking attachments generated by other templates.