### PR TITLE
Fix #611 Fatal Error in WP-CLI Environment. added filter wcdn_enable_pdf to for PDF

### DIFF
--- a/includes/services/class-pdf.php
+++ b/includes/services/class-pdf.php
@@ -52,10 +52,21 @@ class Pdf {
 	 */
 	public function init() {
 
+		if ( ! apply_filters( 'wcdn_enable_pdf', true ) ) {
+				return;
+		}
 		$filesystem = Utils::get_filesystem();
 
 		if ( ! $filesystem ) {
 			return;
+		}
+
+		if ( $filesystem instanceof \WP_Filesystem_FTPext ) {
+			$reflection = new \ReflectionProperty( $filesystem, 'link' );
+			$reflection->setAccessible( true );
+			if ( null === $reflection->getValue( $filesystem ) ) {
+				return; // FTP not connected, bail out safely.
+			}
 		}
 
 		if ( ! as_has_scheduled_action( 'wcdn_delete_pdf_files' ) ) {
@@ -130,7 +141,7 @@ class Pdf {
 		$filesystem  = Utils::get_filesystem();
 		$is_multiple = is_array( $order_id );
 
-		if ( ! $filesystem || ! Settings::get( 'enablePDF' ) ) {
+		if ( ! $filesystem || ! Settings::get( 'enablePDF' ) || ! apply_filters( 'wcdn_enable_pdf', true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fix #611 Fatal Error in WP-CLI Environment

Cause: WordPress filesystem is configured to use FTP, but FTP credentials are unavailable in WP-CLI context, causing ftp_nlist() to receive a null connection. 
Fix: Added a null-connection guard for WP_Filesystem_FTPext in init(), and a wcdn_enable_pdf filter in both init() and generate() to allow disabling PDF entirely.

Also added new filter, wcdn_enable_pdf, which allows PDF generation to be disabled entirely if it is not required.
for testing add this - `add_filter( 'wcdn_enable_pdf', '__return_false' );`