### PR TITLE
Fix #618  WooCommerce Smart Coupons plugin that can cause a fatal error when PDF generation is triggered during coupon email processing.

### DIFF
--- a/includes/services/class-pdf.php
+++ b/includes/services/class-pdf.php
@@ -277,8 +277,10 @@ class Pdf {
 
 		if ( ! $is_sample && ! $is_multiple ) {
 			$order = wc_get_order( $order_id );
-			$order->update_meta_data( '_wcdn_' . $template . '_pdf', $filename );
-			$order->save();
+			if ( $order ) {
+				$order->update_meta_data( '_wcdn_' . $template . '_pdf', $filename );
+				$order->save();
+			}
 		}
 
 		return $file;


### PR DESCRIPTION
Fix #618  WooCommerce Smart Coupons plugin that can cause a fatal error when PDF generation is triggered during coupon email processing.

Fix - added an additional check for order update and saved.