### PR TITLE
Fix #613 Duplicate meta data fields showing.

### DIFF
--- a/includes/services/template/class-template-renderer.php
+++ b/includes/services/template/class-template-renderer.php
@@ -346,6 +346,21 @@ class Template_Renderer {
 			);
 		}
 
+		// Deduplicate $order_meta_fields by 'key' before applying the filter.
+		$seen_keys      = array();
+		$deduped_fields = array();
+		foreach ( $order_meta_fields as $field ) {
+			$key = isset( $field['key'] ) ? (string) $field['key'] : '';
+			if ( '' !== $key ) {
+				if ( isset( $seen_keys[ $key ] ) ) {
+					continue;
+				}
+				$seen_keys[ $key ] = true;
+			}
+			$deduped_fields[] = $field;
+		}
+		$order_meta_fields = $deduped_fields;
+
 		/**
 		 * Filter the order meta fields shown in the document's order data block.
 		 *


### PR DESCRIPTION
Fix #613 Duplicate meta data fields showing.

Cause: $order['extra_fields'] loop and wcdn_order_meta_fields filter (hooked by Delivery & Pickup Pro) both inject the same fields, resulting in duplicate rows in the rendered document.

Fix: Added a key-based deduplication pass after the extra_fields loop and before apply_filters, so the filter still runs normally but duplicate keys are silently skipped.