### PR TITLE
Fix #622 PDF Attachments included in Admin New Order Email when only "Attach PDF to Customer Emails" setting is enabled.

### DIFF
--- a/includes/integrations/class-emails.php
+++ b/includes/integrations/class-emails.php
@@ -169,7 +169,7 @@ class Emails {
 				);
 			}
 
-			if ( $attach_customer && $filesystem->exists( $file_path ) ) {
+			if ( $attach_customer && $filesystem->exists( $file_path ) && 'new_order' !== $email_id ) {
 				$attachments[] = $file_path;
 			}
 


### PR DESCRIPTION
Fix #622 PDF Attachments included in Admin New Order Email when only "Attach PDF to Customer Emails" setting is enabled.