### PR TITLE
Fix #633 Fatal Error After WooCommerce Update.

### DIFF
--- a/includes/class-woocommerce-delivery-notes.php
+++ b/includes/class-woocommerce-delivery-notes.php
@@ -250,10 +250,10 @@ final class WooCommerce_Delivery_Notes {
 			return true;
 		}
 
-		self::include_file( 'class-wcdn-notices.php' );
+		self::include_file( 'admin/class-notices.php' );
 
 		foreach ( $messages as $index => $message ) {
-			WCDN_Notices::add_notice(
+			Notices::add_notice(
 				'plugin_installation_error_notice_' . $index,
 				$message
 			);


### PR DESCRIPTION
Fix #633 Fatal Error After WooCommerce Update.

Cause: file and class not found.
Fix - added proper path + class.